### PR TITLE
Make the H100 model work

### DIFF
--- a/models/H100TC.m
+++ b/models/H100TC.m
@@ -23,31 +23,6 @@ function D=H100TC(alpha, A, B, beta, C, informat, outformat)
 %   D: Result of the operation D = A * B + C computed under the 
 %      specified tensor core configuration.
 
-function D=H100TC(alpha, A, B, beta, C, informat, outformat)
-%
-% H100TC  Compute GEMM with a model of a tensor core of the H100 GPU.
-%
-% This function evaluates the expression D = A * B + C using the 
-% H200 TC numerical-feature-based model. The accumulation of block
-% products is performed using recursive summation.
-%
-% Inputs
-%   A: Left matrix operand for the matrix multiplication A * B.
-%   B: Right matrix operand for the matrix multiplication A * B.
-%   C: Matrix added to the product A * B.
-%   informat: a string specifying the format of A and B.
-%             Supported input formats:
-%                  fp8-(e5m2,e4m3), fp16, binary16, half,
-%                  bf16, bfloat16, tensorfloat32, tf32.
-%   outformat: a string specifying the numerical format for C and D.
-%              Supported output formats:
-%                  fp32, single, binary32,
-%                  fp16, binary16, half.
-%
-% Output
-%   D: Result of the operation D = A * B + C computed under the 
-%      specified tensor core configuration.
-
 % Allowed formats
 allowedOutFormats = {'fp32', 'single', 'binary32',...
     'fp16', 'binary16', 'half'};


### PR DESCRIPTION
@faiziktk Hi, thank you for the amazing modeling paper, this is the first time I saw anyone describe in detail how Tensor Cores actually work in data-center-grade GPUs!

This PR comes from me trying to independently re-implement the BF16 Hopper/Blackwell TC behavior in C++. I was trying to use your MATLAB code as a black-box reference to compare my results against yours, and stumbled upon this error:
<img width="1404" height="186" alt="image" src="https://github.com/user-attachments/assets/da613ee2-1f72-46dc-ab70-e77163687999" />

My MATLAB knowledge is virtually non-existent, but it looks to me like a copy-paste error introduced in [this commit](https://github.com/north-numerical-computing/MATLAB-tensor-core/commit/fa892b0f4cf1e321c38a1b4e085756ee63e85318). I guess the new definition of `H100TC` was supposed to replace the old one (not duplicate it), so this PR tries to fix that.